### PR TITLE
HSM: Session key handling in UART router

### DIFF
--- a/firmware/.cproject
+++ b/firmware/.cproject
@@ -47,7 +47,7 @@
                                     <listOptionValue value="ENABLE_AESADV_GCM=1"/>
                                     <listOptionValue value="CRYPTO_TEST=0"/>
                                     <listOptionValue value="CRYPTO_ENABLE=1"/>
-                                    <listOptionValue value="DEBUG_SKIP_AUTH=1"/>
+                                    <listOptionValue value="DEBUG_SKIP_AUTH=0"/>
                                 </option>
                                 <option id="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.OPT_LEVEL.1227172694" superClass="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.OPT_LEVEL.2" valueType="enumerated"/>
                                 <option id="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.MCPU.1138610546" superClass="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.MCPU" value="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.MCPU.cortex-m0plus" valueType="enumerated"/>

--- a/firmware/.cproject
+++ b/firmware/.cproject
@@ -47,6 +47,7 @@
                                     <listOptionValue value="ENABLE_AESADV_GCM=1"/>
                                     <listOptionValue value="CRYPTO_TEST=0"/>
                                     <listOptionValue value="CRYPTO_ENABLE=1"/>
+                                    <listOptionValue value="DEBUG_SKIP_AUTH=1"/>
                                 </option>
                                 <option id="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.OPT_LEVEL.1227172694" superClass="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.OPT_LEVEL.2" valueType="enumerated"/>
                                 <option id="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.MCPU.1138610546" superClass="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.MCPU" value="com.ti.ccstudio.buildDefinitions.TMS470_TICLANG_4.0.compilerID.MCPU.cortex-m0plus" valueType="enumerated"/>

--- a/firmware/csc/csc_boot.c
+++ b/firmware/csc/csc_boot.c
@@ -1,0 +1,84 @@
+/**
+ * @file csc_boot.c
+ * @author Vault Team - Purdue
+ * @brief Customer Secure Code bootloader implementation
+ * @date 2026
+ */
+
+#include "csc_boot.h"
+#include "../src/customer_secure_config.h"
+#include "../include/driver/flash.h"
+#include "../include/driver/trng.h"
+#include "../include/driver/keystore.h"
+
+#include <string.h>
+#include <ti/driverlib/driverlib.h>
+
+#define PROVISIONING_MAGIC (0xC0FFEE42UL)
+
+static void secure_zero(void *ptr, size_t len)
+{
+    volatile uint8_t *p = (volatile uint8_t *)ptr;
+    while (len--) {
+        *p++ = 0x00;
+    }
+}
+
+// CSC_boot()
+int CSC_boot(void)
+{
+    /* Reject if called after INITDONE — device is no longer privileged */
+    if (DL_SYSCTL_isINITDONEIssued()) {
+        return CSC_BOOT_ERR_LATE;
+    }
+
+    uint32_t magic = 0;
+    flash_read(CSC_LOCK_STORAGE_ADDR, &magic, sizeof(magic));
+
+    bool first_boot = (magic != PROVISIONING_MAGIC);
+
+    if (first_boot) {
+
+        uint32_t new_key[TRNG_256_BIT_BUF_SIZE]; /* 8 × uint32_t = 32 bytes */
+        HSM_TRNG_generate256BitNumber(new_key, sizeof(new_key));
+
+        if (!flash_erase_page(CSC_SECRET_ADDR)) {
+            secure_zero(new_key, sizeof(new_key));
+            return CSC_BOOT_ERR_FLASH;
+        }
+
+        if (!flash_write(CSC_SECRET_ADDR + CSC_ROOT_KEY_OFFSET,
+                         new_key, CSC_ROOT_KEY_SIZE)) {
+            secure_zero(new_key, sizeof(new_key));
+            return CSC_BOOT_ERR_FLASH;
+        }
+
+        /* Wipe key from stack immediately after flash write */
+        secure_zero(new_key, sizeof(new_key));
+
+        if (!flash_erase_page(CSC_LOCK_STORAGE_ADDR)) {
+            return CSC_BOOT_ERR_FLASH;
+        }
+
+        uint32_t sentinel = PROVISIONING_MAGIC;
+        if (!flash_write(CSC_LOCK_STORAGE_ADDR, &sentinel, sizeof(sentinel))) {
+            return CSC_BOOT_ERR_FLASH;
+        }
+    }
+
+    uint32_t *root_key_ptr =
+        (uint32_t *)(CSC_SECRET_ADDR + CSC_ROOT_KEY_OFFSET);
+
+    HSM_KEYSTORE_STATUS ks = HSM_KEYSTORE_initRootKeyStorage(root_key_ptr);
+    if (ks != HSM_KEYSTORE_OK) {
+        return CSC_BOOT_ERR_KEYSTORE;
+    }
+
+    DL_SYSCTL_setReadExecuteProtectFirewallAddrStart(CSC_SECRET_ADDR);
+    DL_SYSCTL_setReadExecuteProtectFirewallAddrEnd(CSC_SECRET_END);
+    DL_SYSCTL_enableReadExecuteProtectFirewall();
+
+    DL_SYSCTL_issueINITDONE();
+
+    return CSC_BOOT_OK;
+}

--- a/firmware/csc/csc_boot.h
+++ b/firmware/csc/csc_boot.h
@@ -1,0 +1,50 @@
+/**
+ * @file csc_boot.h
+ * @author Vault Team - Purdue
+ * @brief Customer Secure Code bootloader
+ * @date 2026
+ *
+ * Runs before INITDONE in privileged state. Handles root key
+ * provisioning on first boot and KEYSTORE + firewall setup on every boot.
+ *
+ * Boot flow - first boot:
+ *  1. TRNG generates 256-bit root key
+ *  2. Root key written to .secret flash sector
+ *  3. Provisioning magic written to .lockStg sector
+ *  4. Root key loaded into KEYSTORE slot 0
+ *  5. Hardware firewall enabled over .secret
+ *  6. INITDONE issued — device leaves privileged state
+ *
+ * Boot flow — subsequent boots:
+ *  1. Root key read from .secret (already provisioned)
+ *  2. Root key loaded into KEYSTORE slot 0
+ *  3. Hardware firewall enabled over .secret
+ *  4. INITDONE issued
+ *
+ * After CSC_boot() returns:
+ *  - INITDONE has been issued
+ *  - .secret is hardware-firewalled
+ *  - Root key is live in KEYSTORE, ready for AESADV transfer
+ */
+
+#ifndef CSC_BOOT_H
+#define CSC_BOOT_H
+
+/* Return codes */
+#define CSC_BOOT_OK (0)
+#define CSC_BOOT_ERR_LATE (-1)  /* Called after INITDONE already issued  */
+#define CSC_BOOT_ERR_TRNG (-2)  /* TRNG generation failed */
+#define CSC_BOOT_ERR_FLASH (-3)  /* Flash erase or write failed */
+#define CSC_BOOT_ERR_KEYSTORE (-4)  /* KEYSTORE write rejected*/
+
+/**
+ * @brief Run the CSC bootloader.
+ *
+ * Must be called from main() after SYSCFG_DL_init() (or SYS_initPower +
+ * peripheral init) befre any HSM application logic
+ *
+ * @return CSC_BOOT_OK on success, negative error code otherwise
+ */
+int CSC_boot(void);
+
+#endif /* CSC_BOOT_H */

--- a/firmware/hsm.theia-workspace
+++ b/firmware/hsm.theia-workspace
@@ -2,6 +2,9 @@
   "folders": [
     {
       "path": ""
+    },
+    {
+      "path": "file:///c%3A/Users/alexa/workspace_ccstheia/aesadv_gcm_128_enc_dec"
     }
   ],
   "settings": {

--- a/firmware/include/auth_engine.h
+++ b/firmware/include/auth_engine.h
@@ -9,4 +9,4 @@
 
 /************************ FUNCTIONS ***********************/
 
-void authentication_engine(uart_frame_t *rx_frame);
+void authentication_engine(uint8_t *pin, size_t len);

--- a/firmware/include/crypto_module.h
+++ b/firmware/include/crypto_module.h
@@ -55,7 +55,6 @@ typedef enum {
  */
 HSM_CRYPTO_STATUS HSM_CRYPTO_init(void);
 
-#ifndef CRYPTO_TEST
 /**
  * @brief Generates the X25519 private session key.
  *
@@ -68,7 +67,6 @@ HSM_CRYPTO_STATUS HSM_CRYPTO_init(void);
  * @retval 6: Failed to import the buffer into the private key struct.
  */
 HSM_CRYPTO_STATUS HSM_CRYPTO_generatePrivateSessionKey(uint8_t *buf, size_t len);
-#endif
 
 #ifdef CRYPTO_TEST
 /**

--- a/firmware/include/crypto_module.h
+++ b/firmware/include/crypto_module.h
@@ -55,7 +55,7 @@ typedef enum {
  */
 HSM_CRYPTO_STATUS HSM_CRYPTO_init(void);
 
-#ifndef ENABLE_HSM_CRYPTO_SESSION_TEST
+#ifndef CRYPTO_TEST
 /**
  * @brief Generates the X25519 private session key.
  *
@@ -70,7 +70,7 @@ HSM_CRYPTO_STATUS HSM_CRYPTO_init(void);
 HSM_CRYPTO_STATUS HSM_CRYPTO_generatePrivateSessionKey(uint8_t *buf, size_t len);
 #endif
 
-#ifdef ENABLE_HSM_CRYPTO_SESSION_TEST
+#ifdef CRYPTO_TEST
 /**
  * @brief Loads the X25519 private session key into the module.
  *

--- a/firmware/include/crypto_module_test.h
+++ b/firmware/include/crypto_module_test.h
@@ -1,8 +1,6 @@
 #ifndef _CRYPTO_MODULE_TEST_H_
 #define _CRYPTO_MODULE_TEST_H_
 
-#define ENABLE_HSM_CRYPTO_SESSION_TEST
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>

--- a/firmware/include/uart_cmd_router.h
+++ b/firmware/include/uart_cmd_router.h
@@ -11,7 +11,11 @@
 #include "ti_drivers_config.h"
 #include <string.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include "uart_protocol.h"
+#include "crypto_module.h"
+#include "auth_engine.h"
+#include "state_machine.h"
 
 // See hsm/assets/docs/uart_protocol.md for list of message types.
 typedef enum {
@@ -21,7 +25,6 @@ typedef enum {
     MSG_SESSION_CLOSE              = 0x0F,
     MSG_FILE_TRANSFER_REQUEST      = 0x20,
     MSG_FILE_CONTENTS              = 0x21,
-    MSG_FILE_TRANSFER_COMPLETE     = 0x22,
     MSG_FILE_REQUEST_ACK           = 0xF0,
     MSG_FILE_TRANSFER_COMPLETE_ACK = 0xF1,
     MSG_PIN_EXCHANGE_ACK           = 0xF2,

--- a/firmware/include/uart_cmd_router.h
+++ b/firmware/include/uart_cmd_router.h
@@ -14,8 +14,6 @@
 #include <stdbool.h>
 #include "uart_protocol.h"
 #include "crypto_module.h"
-#include "auth_engine.h"
-#include "state_machine.h"
 
 // See hsm/assets/docs/uart_protocol.md for list of message types.
 typedef enum {

--- a/firmware/mspm0l2228.cmd
+++ b/firmware/mspm0l2228.cmd
@@ -36,33 +36,35 @@
 
 MEMORY
 {
-FLASH (RX)      : origin = 0x00000000, length = 0x00040000,
-SRAM (RWX)      : origin = 0x20200000, length = 0x00008000,
-/* Non-Main configuration memory */
-BCR_CONFIG(R)   : origin = 0x41C00000, length = 0x000000FF,
-BSL_CONFIG(R)   : origin = 0x41C00100, length = 0x00000080,
+    FLASH        (RX)  : origin = 0x00000000, length = 0x00004000
+    SECRET       (RX)  : origin = 0x00004000, length = 0x00000400
+    LOCK_STORAGE (RX)  : origin = 0x00004400, length = 0x00000400
+    FLASH_APP    (RX)  : origin = 0x00004800, length = 0x0003B800
+    SRAM         (RWX) : origin = 0x20200000, length = 0x00008000
+    BCR_CONFIG   (R)   : origin = 0x41C00000, length = 0x000000FF
+    BSL_CONFIG   (R)   : origin = 0x41C00100, length = 0x00000080
 }
 
 SECTIONS
 {
-    .intvecs:   > 0x00000000
-    .text   : palign(8) {} > FLASH
-    .const  : palign(8) {} > FLASH
-    .cinit  : palign(8) {} > FLASH
-    .pinit  : palign(8) {} > FLASH
-    .rodata : palign(8) {} > FLASH
-    .ARM.exidx    :  palign(8)  {} > FLASH
-    .init_array   :  palign(8)  {} > FLASH
-    .binit        : palign(8) {} > FLASH
-    .TI.ramfunc      : load = FLASH, palign(8), run=SRAM, table(BINIT)
-
-    .vtable :   > SRAM
-    .args   :   > SRAM
-    .data   :   > SRAM
-    .bss    :   > SRAM
-    .sysmem :   > SRAM
-    .stack  :   > SRAM (HIGH)
-
-    .BCRConfig 		       : {} > BCR_CONFIG
-	  .BSLConfig			   : {} > BSL_CONFIG
+    .intvecs      :                  > 0x00000000
+    .text         : palign(8) {}     > FLASH | FLASH_APP
+    .const        : palign(8) {}     > FLASH | FLASH_APP
+    .cinit        : palign(8) {}     > FLASH | FLASH_APP
+    .pinit        : palign(8) {}     > FLASH | FLASH_APP
+    .rodata       : palign(8) {}     > FLASH | FLASH_APP
+    .ARM.exidx    : palign(8) {}     > FLASH | FLASH_APP
+    .init_array   : palign(8) {}     > FLASH | FLASH_APP
+    .binit        : palign(8) {}     > FLASH | FLASH_APP
+    .TI.ramfunc   : load = FLASH, palign(8), run = SRAM, table(BINIT)
+    .secret       : palign(8) {}     > SECRET
+    .lockStg      : (NOINIT) palign(8) {} > LOCK_STORAGE
+    .vtable       :                  > SRAM
+    .args         :                  > SRAM
+    .data         :                  > SRAM
+    .bss          :                  > SRAM
+    .sysmem       :                  > SRAM
+    .stack        :                  > SRAM (HIGH)
+    .BCRConfig    : {}               > BCR_CONFIG
+    .BSLConfig    : {}               > BSL_CONFIG
 }

--- a/firmware/src/auth_engine.c
+++ b/firmware/src/auth_engine.c
@@ -18,7 +18,8 @@
  * state machine runs an exponential holdoff timer after each
  * failed authentication attempt.
  *
- * @param provided_pin PIN received from the UART interface
+ * @param pin PIN received from the UART interface
+ * @param len Length of the received PIN in bytes
  *
  * @return None
  */
@@ -32,11 +33,11 @@
 
 #define SALT_SIZE 32
 
-void authentication_engine(uart_frame_t *rx_frame) {
+void authentication_engine(uint8_t *pin, size_t len) {
     // Initialize Variables
     SystemState state;
-    uint8_t uart_payload[1] = {0};
-    int exp_res = 0, rcv_res = 0;
+    uint8_t uart_payload = 1;
+    int rcv_res = 0;
     byte rcv_pin_hash[MAX_DIGEST_SIZE];
     byte salt[SALT_SIZE] = {
         0xDB, 0x3C, 0x85, 0x59, 0x93, 0x24, 0x47, 0x65,
@@ -57,27 +58,25 @@ void authentication_engine(uart_frame_t *rx_frame) {
     state = system_state_machine(EVENT_NONE);
     if (state != STATE_WAIT_FOR_PIN) {
         //__BKPT();
-        uart_payload[0] = 1;
-        uart_send_frame(MSG_PIN_EXCHANGE_ACK, uart_payload, 1);
+        uart_send_frame(MSG_PIN_EXCHANGE_ACK, &uart_payload, 1);
         return;
     }
 
     rcv_res = wc_HKDF(
         WC_SHA256,
-        rx_frame->payload,
-        (word32)rx_frame->payload_len,
+        pin,
+        (word32)len,
         salt,
         sizeof(salt),
         info,
-        sizeof(info)-1,
+        strlen(info),
         rcv_pin_hash,
         sizeof(rcv_pin_hash)
     );
     
-    if (exp_res != 0 || rcv_res != 0) {
+    if (rcv_res != 0) {
         uart_send_debug_msg("KDF Error");
-        uart_payload[0] = 1;
-        uart_send_frame(MSG_PIN_EXCHANGE_ACK, uart_payload, 1);
+        uart_send_frame(MSG_PIN_EXCHANGE_ACK, &uart_payload, 1);
         return;
     }
     
@@ -85,13 +84,12 @@ void authentication_engine(uart_frame_t *rx_frame) {
     if (memcmp(exp_pin_hash, rcv_pin_hash, MAX_DIGEST_SIZE) == 0) {
         // PINs are identical
         system_state_machine(EVENT_USER_AUTHENTICATED);
-        uart_payload[0] = 0;
+        uart_payload = 0;
         // uart_send_debug_msg("PINs Match");
     } else {
         // PINs do not match
-        system_state_machine(EVENT_INVALID_PIN);
-        uart_payload[0] = 1;    
+        system_state_machine(EVENT_INVALID_PIN); 
         //uart_send_debug_msg("PINs Do Not Match");
     }
-    uart_send_frame(MSG_PIN_EXCHANGE_ACK, uart_payload, 1);
+    uart_send_frame(MSG_PIN_EXCHANGE_ACK, &uart_payload, 1);
 }

--- a/firmware/src/customer_secure_config.h
+++ b/firmware/src/customer_secure_config.h
@@ -1,0 +1,28 @@
+/**
+ * @file customer_secure_config.h
+ * @author Vault Team - Purdue
+ * @brief Memory map constants shared between CSC bootloader and HSM application
+ * @date 2026
+ */
+
+#ifndef CUSTOMER_SECURE_CONFIG_H
+#define CUSTOMER_SECURE_CONFIG_H
+
+/* .secret sector holds the 256-bit TRNG-generated root key
+ * Firewalled by hardware immediately after INITDONE is issued
+ * Size matches one flash sector (1 kB) */
+#define CSC_SECRET_ADDR       (0x00004000UL)
+#define CSC_SECRET_SIZE       (0x00000400UL)
+#define CSC_SECRET_END        (CSC_SECRET_ADDR + CSC_SECRET_SIZE - 1UL)
+
+/* .lockStg sector holds the provisioning magic flag
+ * Remains readable after INITDONE (not firewalled)
+ * Set on first boot to prevent TRNG re-generation on subsequent boots */
+#define CSC_LOCK_STORAGE_ADDR (0x00004400UL)
+#define CSC_LOCK_STORAGE_SIZE (0x00000400UL)
+
+/* Root key layout within .secret */
+#define CSC_ROOT_KEY_OFFSET   (0x00UL)
+#define CSC_ROOT_KEY_SIZE     (32U) /* 256-bit AES key */
+
+#endif /* CUSTOMER_SECURE_CONFIG_H */

--- a/firmware/src/file_manager.c
+++ b/firmware/src/file_manager.c
@@ -12,7 +12,6 @@
 #include <stdbool.h>
 
 #define MAX_SLOTS  8   /* one sector = 8 slots of 128B */
-#define CRYPTO_AES_KEY_SIZE 128
 //#define PIN_BUF_SIZE (PIN_LEN + 1)
 
 static struct {
@@ -162,7 +161,7 @@ static fm_status_t fm_crypto_erase_file_slot(uint8_t slot)
     flash_read(FLASH_BASE_FILE, buf, sizeof(buf));
 
     /* overwrite target slot with TRNG noise */
-    trngGenerateNumber((uint32_t *)&buf[slot], sizeof(fm_layout) / 4);
+    HSM_TRNG_generateNumber((uint32_t *)&buf[slot], sizeof(fm_layout) / sizeof(uint32_t));
 
     /* erase sector */
     if (!flash_erase_page(FLASH_BASE_FILE)) {
@@ -196,7 +195,7 @@ static fm_status_t fm_crypto_erase_key_slot(uint8_t slot)
     fm_key_layout buf[MAX_SLOTS];
     flash_read(FLASH_BASE_KEY, buf, sizeof(buf));
 
-    trngGenerateNumber((uint32_t *)&buf[slot], sizeof(fm_key_layout) / 4);
+    HSM_TRNG_generateNumber((uint32_t *)&buf[slot], sizeof(fm_key_layout) / sizeof(uint32_t));
 
     if (!flash_erase_page(FLASH_BASE_KEY)) {
         return FM_ERROR_FLASH;

--- a/firmware/src/hsm.c
+++ b/firmware/src/hsm.c
@@ -44,7 +44,7 @@ int main(void) {
     init();
     STATUS_LED_OFF();
 
-#if CRYPTO_TEST
+#ifdef CRYPTO_TEST
     // Set breakpoint if we fail crypto session test
     if (!HSM_CRYPTOTEST_sessionTest()) {
         __BKPT();
@@ -68,17 +68,26 @@ int main(void) {
     }
 #endif
     while (1) {
+        // Receive UART frame
         int result = uart_receive_frame(&rx_frame);
         if (result != UART_RECV_FULL_FRAME_RECEIVED) {
             handle_uart_error(result);
             continue;
         }
 
+        // State can't be in lockout
+        sysState = system_state_machine(EVENT_NONE);
+        if (sysState == STATE_LOCKOUT) {
+            uart_send_debug_msg_with_str("ERROR: HSM is locked out", msg_id_to_str(rx_frame.msg_id));
+            continue;
+        }
+
         router_status_t status = router_dispatch(&rx_frame);
         if (status == RT_FAIL) {
             uart_send_debug_msg_with_str("ERROR: Router dispatch failed for msg_id", msg_id_to_str(rx_frame.msg_id));
+            continue;
         }
-        sysState = system_state_machine(EVENT_NONE);
+        
         if (sysState == STATE_UNLOCKED) {
             STATUS_LED_ON();
             uart_send_debug_msg("unlocked");

--- a/firmware/src/hsm.c
+++ b/firmware/src/hsm.c
@@ -19,11 +19,14 @@
 #include "state_machine.h"
 #include "file_manager.h"
 
+#include "../csc/csc_boot.h"
+#include "driver/keystore.h"
+
 /** @brief Initializes peripherals for system boot.
 */
 void init() {
-    // Initialize all of the hardware components
     SYS_initPower();
+    // Initialize all of the hardware components
     GPIO_init();
     TIMER_0_init();
     TIMER_1_init();
@@ -37,9 +40,14 @@ void init() {
 int main(void) {
     uart_frame_t rx_frame;
     SystemState sysState;
-
-    //uart_msg_id_t cmd;
-
+#if 0
+    int csc_rc = CSC_boot();
+    if (csc_rc != CSC_BOOT_OK) {
+        //Error in CSC
+        while (1) { __WFI(); }
+    }
+    HSM_KEYSTORE_transferRootKeyToAES();
+#endif
     // Initialize device peripherals
     init();
     STATUS_LED_OFF();

--- a/firmware/src/state_machine.c
+++ b/firmware/src/state_machine.c
@@ -27,7 +27,11 @@
 
 SystemState system_state_machine(SystemStateEvent event) {
     
+#ifdef DEBUG_SKIP_AUTH
+    static SystemState state = STATE_UNLOCKED;
+#else
     static SystemState state = STATE_WAIT_FOR_UART;
+#endif
     static uint8_t invalid_pin_count = 0;
     const uint8_t MAX_RETRIES = 10;
     volatile uint16_t timer_load_val;

--- a/firmware/src/uart_cmd_router.c
+++ b/firmware/src/uart_cmd_router.c
@@ -63,11 +63,18 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
         return RT_FAIL;
     }
 
-    // Session check
+    // Session check 
+    #ifndef DEBUG_SKIP_AUTH
     if (!HSM_UART_ROUTER_validSessionEstablished(rx_frame)) {
         uart_send_debug_msg("ERROR: invalid session");
         return RT_FAIL;
     }
+    sys_state = system_state_machine(EVENT_NONE);
+    if (sys_state != STATE_UNLOCKED) {
+        uart_send_debug_msg("ERROR: not unlocked");
+        return RT_FAIL;
+    }
+    #endif
     
     //__BKPT();
     sys_state = system_state_machine(EVENT_NONE);

--- a/firmware/src/uart_cmd_router.c
+++ b/firmware/src/uart_cmd_router.c
@@ -7,6 +7,8 @@
 
 #include "uart_cmd_router.h"
 #include "file_manager.h"
+#include "auth_engine.h"
+#include "state_machine.h"
 
 /************************* GLOBALS ************************/
 
@@ -27,13 +29,13 @@ static bool sessionEstablished = false;
 bool HSM_UART_ROUTER_validSessionEstablished(uart_frame_t *rx_frame) {
 
     // Null check (shouldn't happen, but just in case)
-    if (!frame) return false;
+    if (!rx_frame) return false;
 
     // If not session open / close, check against sessionEstablished
     if (
-        frame->msg_id == MSG_SESSION_OPEN
-        || frame->msg_id == MSG_KEY_EXCHANGE
-        || frame->msg_id == MSG_SESSION_CLOSE
+        rx_frame->msg_id == MSG_SESSION_OPEN
+        || rx_frame->msg_id == MSG_KEY_EXCHANGE
+        || rx_frame->msg_id == MSG_SESSION_CLOSE
     ) return true;
     return sessionEstablished;
 }
@@ -54,6 +56,8 @@ void HSM_UART_ROUTER_clearSessionData(void) {
 
 router_status_t router_dispatch(uart_frame_t *rx_frame) {
     SystemState sys_state;
+    uint8_t ack_payload = 0;
+    uint8_t err_ack_payload = 1;
     if (rx_frame == NULL) {
         uart_send_debug_msg("ERROR: Null frame in router");
         return RT_FAIL;
@@ -71,8 +75,6 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
 
         case MSG_SESSION_OPEN:
             uart_send_debug_msg("Session Open message received.");
-            
-            uint8_t err_ack_payload = 1;
 
             // State machine check
             if (sys_state != STATE_WAIT_FOR_UART) {
@@ -82,7 +84,7 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
             }
 
             // Validate syntax according to UART frame ICD
-            if (rx_frame->payload_len != 1 || !rx_frame->payload || rx_frame->payload[0] != 0x41) {
+            if (rx_frame->payload_len != 1 || rx_frame->payload[0] != 0x41) {
                 HSM_UART_ROUTER_clearSessionData();
                 (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
                 return RT_FAIL;
@@ -111,15 +113,12 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
 
             // Send acknoledgement
             memset(privECDH, 0, CRYPTO_AES_KEY_SIZE);
-            err_ack_payload = 0;
-            (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+            (void) uart_send_frame(rx_frame->msg_id, &ack_payload, 1);
             
             return RT_OK;
 
         case MSG_KEY_EXCHANGE:
             uart_send_debug_msg("Key Exchange message received.");
-
-            const uint8_t err_ack_payload = 1;
 
             // State machine check
             if (sys_state != STATE_WAIT_FOR_UART) {
@@ -128,7 +127,7 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
             }
 
             // Validate syntax according to UART frame ICD
-            if (rx_frame->payload_len != CRYPTO_AES_KEY_SIZE || !rx_frame->payload) {
+            if (rx_frame->payload_len != CRYPTO_AES_KEY_SIZE) {
                 (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
                 return RT_FAIL;
             }
@@ -175,10 +174,8 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
             
             return RT_OK;
 
-        case MSG_PIN_EXCHANGE:
+        case MSG_PIN_EXCHANGE: {
             uart_send_debug_msg("PIN Exchange message received.");
-
-            const uint8_t err_ack_payload = 1;
             
             // State machine check
             if (sys_state != STATE_WAIT_FOR_PIN) {
@@ -187,7 +184,7 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
             }
 
             // Validate syntax according to UART frame ICD
-            if (rx_frame->payload_len <= CRYPTO_GCM_TAG_SIZE || !rx_frame->payload) {
+            if (rx_frame->payload_len <= CRYPTO_GCM_TAG_SIZE) {
                 (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
                 return RT_FAIL;
             }
@@ -217,11 +214,10 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
             authentication_engine(pin, pinlen);
 
             return RT_OK;
+        }
 
         case MSG_SESSION_CLOSE:
             uart_send_debug_msg("Session Close message received.");
-
-            const uint8_t err_ack_payload = 0;
             
             // Clear all session data
             HSM_UART_ROUTER_clearSessionData();

--- a/firmware/src/uart_cmd_router.c
+++ b/firmware/src/uart_cmd_router.c
@@ -7,52 +7,231 @@
 
 #include "uart_cmd_router.h"
 #include "file_manager.h"
-#include "auth_engine.h"
-#include "state_machine.h"
+
+/************************* GLOBALS ************************/
+
+static uint8_t pubECDH[CRYPTO_AES_KEY_SIZE] = {0};
+static uint8_t sessionKey[CRYPTO_AES_KEY_SIZE] = {0};
+static uint8_t sessionIv[CRYPTO_GCM_IV_SIZE] = {0};
+static bool sessionEstablished = false;
 
 /************************ FUNCTIONS ***********************/
+
+/**
+ * @brief Verifies that a session has been established.
+ * 
+ * @param rx_frame Pointer to a received UART frame from the Host CLI.
+ *
+ * @returns true if valid session has been established
+ */
+bool HSM_UART_ROUTER_validSessionEstablished(uart_frame_t *rx_frame) {
+
+    // Null check (shouldn't happen, but just in case)
+    if (!frame) return false;
+
+    // If not session open / close, check against sessionEstablished
+    if (
+        frame->msg_id == MSG_SESSION_OPEN
+        || frame->msg_id == MSG_KEY_EXCHANGE
+        || frame->msg_id == MSG_SESSION_CLOSE
+    ) return true;
+    return sessionEstablished;
+}
+
+/**
+ * @brief Clears the session data.
+ */
+void HSM_UART_ROUTER_clearSessionData(void) {
+
+    // Zeroize all buffers related to session
+    memset(pubECDH, 0, CRYPTO_AES_KEY_SIZE);
+    memset(sessionKey, 0, CRYPTO_AES_KEY_SIZE);
+    memset(sessionIv, 0, CRYPTO_GCM_IV_SIZE);
+
+    // Indicates valid session has not been established
+    sessionEstablished = false;
+}
+
 router_status_t router_dispatch(uart_frame_t *rx_frame) {
     SystemState sys_state;
     if (rx_frame == NULL) {
         uart_send_debug_msg("ERROR: Null frame in router");
         return RT_FAIL;
     }
+
+    // Session check
+    if (!HSM_UART_ROUTER_validSessionEstablished(rx_frame)) {
+        uart_send_debug_msg("ERROR: invalid session");
+        return RT_FAIL;
+    }
+    
     //__BKPT();
     sys_state = system_state_machine(EVENT_NONE);
     switch (rx_frame->msg_id) {
+
         case MSG_SESSION_OPEN:
             uart_send_debug_msg("Session Open message received.");
-            if (sys_state == STATE_WAIT_FOR_UART) {
-                // TODO (Aidan): Open UART Session
-                // Aidan: The call below is a stub to keep state flow moving until the ECDH session is established.  
-                //        Please move the call to whatever module you feel is the most appropriate location.
-                //        See auth_engine.c for an example of how I issue EVENT_USER_AUTHENTICATED.
-                sys_state = system_state_machine(EVENT_UART_SESSION_ESTABLISHED);
+            
+            uint8_t err_ack_payload = 1;
+
+            // State machine check
+            if (sys_state != STATE_WAIT_FOR_UART) {
+                HSM_UART_ROUTER_clearSessionData();
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
             }
+
+            // Validate syntax according to UART frame ICD
+            if (rx_frame->payload_len != 1 || !rx_frame->payload || rx_frame->payload[0] != 0x41) {
+                HSM_UART_ROUTER_clearSessionData();
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+
+            // Clear all session data
+            HSM_UART_ROUTER_clearSessionData();
+            
+            // Generate private key
+            uint8_t privECDH[CRYPTO_AES_KEY_SIZE];
+            memset(privECDH, 0, CRYPTO_AES_KEY_SIZE);
+            if (HSM_CRYPTO_generatePrivateSessionKey(privECDH, CRYPTO_AES_KEY_SIZE) != HSM_CRYPTO_OK) {
+                memset(privECDH, 0, CRYPTO_AES_KEY_SIZE);
+                HSM_UART_ROUTER_clearSessionData();
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+
+            // Generate public key
+            if (HSM_CRYPTO_generatePublicSessionKey(privECDH, pubECDH, CRYPTO_AES_KEY_SIZE) != HSM_CRYPTO_OK) {
+                memset(privECDH, 0, CRYPTO_AES_KEY_SIZE);
+                HSM_UART_ROUTER_clearSessionData();
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+
+            // Send acknoledgement
+            memset(privECDH, 0, CRYPTO_AES_KEY_SIZE);
+            err_ack_payload = 0;
+            (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+            
             return RT_OK;
 
         case MSG_KEY_EXCHANGE:
             uart_send_debug_msg("Key Exchange message received.");
-            if (sys_state == STATE_WAIT_FOR_UART) {
-                // TODO (Aidan): Open UART Session
-                // Aidan: The call below is a stub to keep state flow moving until the ECDH session is established.  
-                //        Please move the call to whatever module you feel is the most appropriate location.
-                //        See auth_engine.c for an example of how I issue EVENT_USER_AUTHENTICATED.
-                sys_state = system_state_machine(EVENT_UART_SESSION_ESTABLISHED);
+
+            const uint8_t err_ack_payload = 1;
+
+            // State machine check
+            if (sys_state != STATE_WAIT_FOR_UART) {
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
             }
+
+            // Validate syntax according to UART frame ICD
+            if (rx_frame->payload_len != CRYPTO_AES_KEY_SIZE || !rx_frame->payload) {
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+
+            // Load client public key into session
+            if (HSM_CRYPTO_loadClientPublicKey(rx_frame->payload, rx_frame->payload_len) != HSM_CRYPTO_OK) {
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+
+            // Generate shared secret
+            uint8_t secret[CRYPTO_AES_KEY_SIZE];
+            memset(secret, 0, CRYPTO_AES_KEY_SIZE);
+            if (HSM_CRYPTO_generateSharedSecret(secret, CRYPTO_AES_KEY_SIZE) != HSM_CRYPTO_OK) {
+                memset(secret, 0, CRYPTO_AES_KEY_SIZE);
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+
+            // Derive session key and IV
+            uint8_t tempKey[CRYPTO_AES_KEY_SIZE];
+            uint8_t tempIv[CRYPTO_GCM_IV_SIZE];
+            if (HSM_CRYPTO_deriveKeyAndIV(secret, tempKey, CRYPTO_AES_KEY_SIZE, tempIv, CRYPTO_GCM_IV_SIZE) != HSM_CRYPTO_OK) {
+                memset(tempKey, 0, CRYPTO_AES_KEY_SIZE);
+                memset(tempIv, 0, CRYPTO_GCM_IV_SIZE);
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+
+            // Load generated values into session variables
+            memset(sessionKey, 0, CRYPTO_AES_KEY_SIZE);
+            memset(sessionIv, 0, CRYPTO_GCM_IV_SIZE);
+            memcpy(sessionKey, tempKey, CRYPTO_AES_KEY_SIZE);
+            memcpy(sessionIv, tempIv, CRYPTO_GCM_IV_SIZE);
+            memset(tempKey, 0, CRYPTO_AES_KEY_SIZE);
+            memset(tempIv, 0, CRYPTO_GCM_IV_SIZE);
+            sessionEstablished = true;
+            
+            // Update state machine
+            sys_state = system_state_machine(EVENT_UART_SESSION_ESTABLISHED);
+            
+            // Send public key on success
+            (void) uart_send_frame(rx_frame->msg_id, pubECDH, CRYPTO_AES_KEY_SIZE);
+            
             return RT_OK;
 
         case MSG_PIN_EXCHANGE:
             uart_send_debug_msg("PIN Exchange message received.");
-            if (sys_state == STATE_WAIT_FOR_PIN) {
-                authentication_engine(rx_frame);
+
+            const uint8_t err_ack_payload = 1;
+            
+            // State machine check
+            if (sys_state != STATE_WAIT_FOR_PIN) {
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
             }
+
+            // Validate syntax according to UART frame ICD
+            if (rx_frame->payload_len <= CRYPTO_GCM_TAG_SIZE || !rx_frame->payload) {
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+
+            // Decrypt the PIN
+            size_t pinlen = rx_frame->payload_len - CRYPTO_GCM_TAG_SIZE;
+            uint8_t pin[pinlen];
+            memset(pin, 0, pinlen);
+            if (
+                HSM_CRYPTO_decryptCommandPayload(
+                    sessionKey,
+                    CRYPTO_AES_KEY_SIZE,
+                    sessionIv,
+                    CRYPTO_GCM_IV_SIZE,
+                    rx_frame->payload,
+                    CRYPTO_GCM_TAG_SIZE,
+                    &rx_frame->payload[pinlen],
+                    pin,
+                    pinlen
+                ) != HSM_CRYPTO_OK
+            ) {
+                (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+                return RT_FAIL;
+            }
+            
+            // Send PIN to auth engine (handles the UART messaging over there)
+            authentication_engine(pin, pinlen);
+
             return RT_OK;
 
         case MSG_SESSION_CLOSE:
             uart_send_debug_msg("Session Close message received.");
-            // TODO (Alex): Need to tear down the ECDH session here
+
+            const uint8_t err_ack_payload = 0;
+            
+            // Clear all session data
+            HSM_UART_ROUTER_clearSessionData();
+
+            // Update state machine
             sys_state = system_state_machine(EVENT_SESSION_CLOSE_USER);
+
+            // Send acknowledgement
+            (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
+
             return RT_OK;
 
         case MSG_FILE_TRANSFER_REQUEST:
@@ -81,7 +260,6 @@ const char* msg_id_to_str(uint8_t msg_id) {
         case MSG_SESSION_CLOSE:              return "SESSION_CLOSE";
         case MSG_FILE_TRANSFER_REQUEST:      return "FILE_TRANSFER_REQUEST";
         case MSG_FILE_CONTENTS:              return "FILE_CONTENTS";
-        case MSG_FILE_TRANSFER_COMPLETE:     return "FILE_TRANSFER_COMPLETE";
         case MSG_FILE_REQUEST_ACK:           return "FILE_REQUEST_ACK";
         case MSG_FILE_TRANSFER_COMPLETE_ACK: return "FILE_TRANSFER_COMPLETE_ACK";
         case MSG_PIN_EXCHANGE_ACK:           return "PIN_EXCHANGE_ACK";

--- a/firmware/src/uart_cmd_router.c
+++ b/firmware/src/uart_cmd_router.c
@@ -113,7 +113,6 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
 
             // Send acknoledgement
             memset(privECDH, 0, CRYPTO_AES_KEY_SIZE);
-            (void) uart_send_frame(rx_frame->msg_id, &ack_payload, 1);
             
             return RT_OK;
 
@@ -131,7 +130,7 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
                 (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
                 return RT_FAIL;
             }
-
+    
             // Load client public key into session
             if (HSM_CRYPTO_loadClientPublicKey(rx_frame->payload, rx_frame->payload_len) != HSM_CRYPTO_OK) {
                 (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
@@ -201,7 +200,7 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
                     CRYPTO_GCM_IV_SIZE,
                     rx_frame->payload,
                     CRYPTO_GCM_TAG_SIZE,
-                    &rx_frame->payload[pinlen],
+                    &rx_frame->payload[CRYPTO_GCM_TAG_SIZE],
                     pin,
                     pinlen
                 ) != HSM_CRYPTO_OK
@@ -209,7 +208,7 @@ router_status_t router_dispatch(uart_frame_t *rx_frame) {
                 (void) uart_send_frame(rx_frame->msg_id, &err_ack_payload, 1);
                 return RT_FAIL;
             }
-            
+
             // Send PIN to auth engine (handles the UART messaging over there)
             authentication_engine(pin, pinlen);
 


### PR DESCRIPTION
Closes #9.

This MR implements the session key handling for the HSM, including storage and state machine interactions. The session key procedure was already tested previously in a CRYPTO module test, so we know that this works.

Currently the only thing it is being used for is decrypting the PIN to test the functionality. Once we verify this works, @RiccardoLenti will be able to come in and bring his changes that he made for session encryption and decryption. DO NOT APPROVE THIS MR WITHOUT HIS APPROVAL.

Some other small changes:
- Lockout checking in `hsm.c`
- Update to auth engine interface + small syntax fixes
- File manager uses proper AES key size, TRNG calls
